### PR TITLE
[makefile] Fix Dune invocation to support embedding method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,40 @@
-.PHONY: $(DUNE) help clean submodules
+.PHONY: help universe dune submodules clean install-opam-deps
 
-#
 # This build works without dune being installed. In order for this to work, we
 # use the bootstrapping mechanism in the build of dune.
-#
 
-DUNE_EXE=dune-ocaml/dune.exe
-DUNE=$(DUNE_EXE) exec --root dune-ocaml -- dune
+ifdef OS
+	EXE=.exe
+else
+	EXE=
+endif
+
+DUNE=./dune-ocaml/_build/install/default/bin/dune$(EXE)
 
 OPAM_DEPS=\
-	ocamlfind\
-	zarith\
+	ocamlfind \
+	zarith \
 	menhir
 
 help:
 	@echo "Welcome to Coq Universe, do 'make universe' to build"
 	@echo "If the submodules are not fetched, first do 'make submodules'"
 
-$(DUNE_EXE):
-	make -C dune-ocaml dune.exe
+$(DUNE):
+	cd dune-ocaml && make release
 
-universe: $(DUNE_EXE)
+universe: $(DUNE)
 	$(DUNE) build @install --display=short --error-reporting=twice
 
-dune: $(DUNE_EXE)
+dune: $(DUNE)
 	$(DUNE) $(ARGS)
 
 submodules:
 	git submodule update --init --recursive
 
-clean: $(DUNE_EXE)
+clean: $(DUNE)
 	$(DUNE) clean
-	$(DUNE_EXE) clean --root dune-ocaml
+	$(DUNE) clean --root dune-ocaml
 
 install-opam-deps:
 	opam install $(OPAM_DEPS) -y $(ARGS)


### PR DESCRIPTION
Building and using `dune` as an standalone binary is supported but it
has to be the toplevel call, and at the right location.

Fixed a few things more like bogus and missing `.PHONY` targets.