### PR TITLE
[CI] reduce OCaml versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
         ocaml-compiler:
-          - 4.09.1
-          - 4.14.0
           - ocaml-variants.4.14.0+options,ocaml-option-flambda
-        exclude:
+        include:
           - os: windows-latest
-            ocaml-compiler: ocaml-variants.4.14.0+options,ocaml-option-flambda
+            ocaml-compiler: 4.14
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We reduce to 4.14+flambda for ubuntu and macos and 4.14 for windows (since I couldn't get flambda working).